### PR TITLE
[codex] Use split sales order list APIs

### DIFF
--- a/src/api/sales-order.api.ts
+++ b/src/api/sales-order.api.ts
@@ -7,17 +7,29 @@ import type {
   VehicleAssignmentRequirement
 } from '@/domain/order/order.types'
 
+function getPagedList(url: string, params: any) {
+  const { current, size, ...rest } = params
+  return request.get<SalesOrderList>({
+    url,
+    params: {
+      Page: current,
+      PageSize: size,
+      ...rest
+    }
+  })
+}
+
 export const SalesOrderApi = {
   getList(params: any) {
-    const { current, size, ...rest } = params
-    return request.get<SalesOrderList>({
-      url: '/api/SalesOrders',
-      params: {
-        Page: current,
-        PageSize: size,
-        ...rest
-      }
-    })
+    return getPagedList('/api/v1/SalesOrders', params)
+  },
+
+  getConfirmedList(params: any) {
+    return getPagedList('/api/v1/SalesOrders/confirmed', params)
+  },
+
+  getUnconfirmedList(params: any) {
+    return getPagedList('/api/v1/SalesOrders/unconfirmed', params)
   },
 
   getById(id: number) {

--- a/src/domain/constants/permissions.ts
+++ b/src/domain/constants/permissions.ts
@@ -23,6 +23,8 @@ export const Permissions = {
   InputsDelete: 'Permissions.Inputs.Delete',
   InputsChangeStatus: 'Permissions.Inputs.ChangeStatus',
   OutputsView: 'Permissions.Outputs.View',
+  OutputsViewConfirmed: 'Permissions.Outputs.ViewConfirmed',
+  OutputsViewUnconfirmed: 'Permissions.Outputs.ViewUnconfirmed',
   OutputsCreate: 'Permissions.Outputs.Create',
   OutputsEdit: 'Permissions.Outputs.Edit',
   OutputsDelete: 'Permissions.Outputs.Delete',

--- a/src/views/sales/draft/index.vue
+++ b/src/views/sales/draft/index.vue
@@ -630,7 +630,7 @@
     try {
       const filters: string[] = []
       if (searchForm.statusId) filters.push(`StatusId==${searchForm.statusId}`)
-      const res = await SalesOrderApi.getList({
+      const res = await SalesOrderApi.getUnconfirmedList({
         current: pagination.current,
         size: pagination.size,
         Filters: filters.join('|') || undefined,

--- a/src/views/sales/order/index.vue
+++ b/src/views/sales/order/index.vue
@@ -630,7 +630,7 @@
     try {
       const filters: string[] = []
       if (searchForm.statusId) filters.push(`StatusId==${searchForm.statusId}`)
-      const res = await SalesOrderApi.getList({
+      const res = await SalesOrderApi.getConfirmedList({
         current: pagination.current,
         size: pagination.size,
         Filters: filters.join('|') || undefined,


### PR DESCRIPTION
## Summary

- Add Management permission constants for confirmed and unconfirmed sales-order list permissions.
- Add API client helpers for /api/v1/SalesOrders/confirmed and /api/v1/SalesOrders/unconfirmed.
- Point Phiếu tạm to the unconfirmed list API and Phiếu bán hàng to the confirmed list API.

## Validation

- npm run build: passed

## Notes

Targets Management-sales-receipt because this branch was created from Management-sales-receipt.